### PR TITLE
Allow easy migration to 18xx Route Finder.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 routes-1846 == 0.21
 
-Flask == 1.0.2
-Flask-WTF==0.14.2
+Flask == 1.1.2
+Flask-WTF==0.14.3
 Flask-Mail == 0.9.1
 
 redis == 2.10.6
 rq == 0.12
+
+requests == 2.24.0

--- a/routes1846web/templates/index.html
+++ b/routes1846web/templates/index.html
@@ -5,6 +5,8 @@
     <span style="display: inline-block; font-size: 2rem; font-family: inherit; font-weight: 500;">1846 Route Calculator</span>
     <span>&nbsp;</span>
     <button type="button" class="btn btn-sm btn-outline-info align-middle align-text-bottom" data-toggle="modal" data-target="#aboutModal">About</button>
+    <span>&nbsp;</span>
+    <span style="vertical-align: text-top"><a href="#" data-toggle="modal" data-target="#migration-modal" style="vertical-align: bottom">Migrate to 18xx</a></span>
     <button id="general-report-issue-open" class="float-right btn btn-outline-danger" data-toggle="modal" data-target="#general-report-issue-modal" style="margin-right: 25px;">Report Issue</button>
 </div>
 <div id="controls" style="margin-bottom: 10px; width: 100%; text-align: center">
@@ -130,6 +132,32 @@
             </div>
             <div class="modal-footer">
                 <button class="btn btn-primary" type="button" id="global-import-save">Save</button>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="modal fade" id="migration-modal" tabindex="-1" role="dialog" aria-labelledby="migration-modal" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2>Migrate to 18xx Route Finder?</h2>
+            </div>
+            <div class="modal-body">
+                <p>
+                    This app has been deprecated in favor of <a href="https://routes18xx.herokuapp.com/">18xx Route Finder</a>.
+                </p>
+                <p>
+                    18xx Router Finder is a fork of this app, so its interface and operation are exactly the same. It also fixes some bugs an implements some minor new features. The present (and future) changes are documented <a href="https://github.com/Auzzy/18xx-routes-web/wiki">on GitHub</a>.
+                </p>
+                <p>
+                    To bring your current game data into 18xx Router Finder, click "Migrate!". It will convert your game data, load it into the new app, and redirect you to the new site. You can also dismiss this modal permanently ("Dismiss"), or just close it until you next visit the page ("Remind Me Later").
+                </p>
+                <div id="migration-message"></div>
+            </div>
+            <div class="modal-footer">
+                <button id="migrate-dismiss" class="btn btn-outline-danger" type="button">Dismiss</button>
+                <button id="migrate-later" class="btn btn-outline-dark" type="button">Remind Me Later</button>
+                <button id="migrate-start" class="btn btn-success" type="button">Migrate!</button>
             </div>
         </div>
     </div>
@@ -306,6 +334,44 @@ $("#global-import-export-modal").on("show.bs.modal", function() {
 
     enableSubmitViaKeyboard($("#global-import-export-modal"), $("#global-import-save"));
 });
+
+$("#migrate-dismiss").click(() => {
+    localStorage.showMigrationModal = "false";
+    $("#migration-modal").modal('hide');
+});
+
+$("#migrate-later").click(() => {
+    $("#migration-modal").modal('hide');
+});
+
+$("#migrate-start").click(() => {
+    var migrationData = {
+        "placedTilesTable": localStorage.placedTilesTable,
+        "removedRailroadsTable": localStorage.removedRailroadsTable,
+        "railroadsTable": localStorage.railroadsTable,
+        "privateCompaniesTable": localStorage.privateCompaniesTable,
+        "hideCityPaths": localStorage.hideCityPaths
+    };
+    $.post("{{ url_for('migrate') }}", {migrationData: JSON.stringify(migrationData)})
+        .done(response => {
+            $("#migration-message")
+                .empty()
+                .css("color", "green")
+                .text(`Success! Redirecting you...`);
+            localStorage.showMigrationModal = "false";
+            window.location.href = `${response["target"]}/migrate/complete?id=${response["id"]}`;
+        })
+        .fail(resultObj => {
+            $("#migration-message")
+                .empty()
+                .css("color", "red")
+                .text(`Migration error: ${resultObj["responseJSON"]["error"]}`);
+        });
+});
+
+if (isEmpty(localStorage.showMigrationModal) || localStorage.showMigrationModal === "true") {
+    $("#migration-modal").modal("show");
+}
 
 {% include "js/placed-tiles-map.js.html" %}
 

--- a/routes1846web/views.py
+++ b/routes1846web/views.py
@@ -1,6 +1,7 @@
 import collections
 import json
 import os
+import requests
 
 from flask import jsonify, render_template, request, url_for
 from flask_mail import Message
@@ -107,6 +108,31 @@ def get_tile_coords():
                     tile_coords.append(coord)
         _TILE_COORDS = tile_coords
     return _TILE_COORDS
+
+@app.route("/migrate", methods=["POST"])
+def migrate():
+    LOG.info("Migration requested")
+
+    migration_data = request.form["migrationData"]
+    if not migration_data:
+        LOG.debug("Migration failure: no data provided")
+        return jsonify({"error": "No data provided."}), 400
+
+    url_18xx = os.environ.get("URL18XX")
+    if not url_18xx:
+        LOG.debug("Migration failure: could not find the URL for the 18xx app.")
+        return jsonify({"error": "Failed to begin."}), 500
+
+    LOG.debug("Initiating migration to 18xx")
+    response = requests.post(f"{url_18xx}/migrate/start", data=migration_data)
+    response_json = response.json()
+    if response.ok:
+        response_json["target"] = url_18xx
+        LOG.debug(f"Migration: received migration id {response_json['id']}.")
+    else:
+        LOG.debug(f"Migration failure: {response_json['error']}")
+
+    return jsonify(response_json), response.status_code
 
 @app.route("/")
 def main():


### PR DESCRIPTION
When a user visits the site, they're greeted with a modal. "Migrate!" will collect their local storage and send it to the new app, then redirect them to the 1846 page of the app, with their data loaded. If they click "Remind Me Later" or "Dismiss", the modal will close. The difference is "Dismiss" sets a localStorage variable which results in the modal not opening on the user's next visit.

The user can re-open the modal at any time by clicking the "Migrate to 18xx" link.

Resolves #79 